### PR TITLE
Improve messaging when Firebase email auth is disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,32 +25,79 @@
         .table-row:nth-child(even) { background-color: #1a202c; }
         .modal { display: none; position: fixed; z-index: 100; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.6); backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px); justify-content: center; align-items: center; }
         .modal-content { background-color: #2d3748; margin: auto; padding: 24px; border: 1px solid #4a5568; width: 90%; max-width: 400px; border-radius: 12px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); text-align: center; }
+        .auth-overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: radial-gradient(circle at top, rgba(76, 81, 191, 0.25), transparent), rgba(17, 24, 39, 0.95); z-index: 200; padding: 24px; }
+        .auth-card { border: 1px solid rgba(99, 179, 237, 0.2); backdrop-filter: blur(6px); }
+        .auth-card .btn-primary { width: 100%; }
     </style>
 </head>
 <body class="bg-gray-900 text-gray-200">
 
-    <div id="loadingIndicator" class="fixed inset-0 bg-gray-900 bg-opacity-75 z-50 flex items-center justify-center hidden">
-        <div class="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-purple-500"></div>
-        <div class="ml-4 text-white">Fetching rates...</div>
-    </div>
+    <div id="authOverlay" class="auth-overlay hidden">
+        <div class="auth-card bg-gray-800 p-8 rounded-xl shadow-2xl w-full max-w-md">
+            <h2 id="authTitle" class="text-3xl font-bold text-center mb-6 text-indigo-400">Sign In</h2>
+            <div id="authMessage" class="text-sm text-center mb-4 hidden"></div>
 
-    <div id="successMessage" class="fixed top-4 right-4 bg-green-500 text-white py-2 px-4 rounded-full shadow-lg z-50 transition-transform transform translate-x-full hidden">Activity Logged!</div>
-    <div id="errorMessage" class="fixed top-4 right-4 bg-red-500 text-white py-2 px-4 rounded-full shadow-lg z-50 transition-transform transform hidden">Failed to log activity. Please try again.</div>
+            <form id="loginForm" class="space-y-4">
+                <div>
+                    <label for="loginEmail" class="block text-sm font-medium mb-1">Email</label>
+                    <input id="loginEmail" type="email" class="form-input" required autocomplete="email">
+                </div>
+                <div>
+                    <label for="loginPassword" class="block text-sm font-medium mb-1">Password</label>
+                    <input id="loginPassword" type="password" class="form-input" required autocomplete="current-password">
+                </div>
+                <button type="submit" class="btn-primary w-full">Sign In</button>
+            </form>
 
-    <div id="deleteModal" class="modal">
-        <div class="modal-content">
-            <h3 class="text-xl font-bold mb-4">Confirm Deletion</h3>
-            <p class="mb-6">Are you sure you want to delete this entry?</p>
-            <div class="flex justify-center gap-4">
-                <button id="confirmDeleteBtn" class="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-6 rounded-full transition-colors">Delete</button>
-                <button id="cancelDeleteBtn" class="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-6 rounded-full transition-colors">Cancel</button>
+            <form id="registerForm" class="space-y-4 hidden">
+                <div>
+                    <label for="registerEmail" class="block text-sm font-medium mb-1">Email</label>
+                    <input id="registerEmail" type="email" class="form-input" required autocomplete="email">
+                </div>
+                <div>
+                    <label for="registerPassword" class="block text-sm font-medium mb-1">Password</label>
+                    <input id="registerPassword" type="password" class="form-input" required minlength="6" autocomplete="new-password">
+                </div>
+                <div>
+                    <label for="registerPasswordConfirm" class="block text-sm font-medium mb-1">Confirm Password</label>
+                    <input id="registerPasswordConfirm" type="password" class="form-input" required minlength="6" autocomplete="new-password">
+                </div>
+                <button type="submit" class="btn-primary w-full">Create Account</button>
+            </form>
+
+            <div class="mt-6 text-center text-sm text-gray-400">
+                <span id="toggleAuthText">Don't have an account?</span>
+                <button id="toggleAuthBtn" type="button" class="text-indigo-400 font-semibold hover:underline ml-1">Register</button>
             </div>
         </div>
     </div>
 
-    <div class="container mx-auto p-8 lg:p-12">
+    <div id="appContent" class="hidden">
+        <div id="loadingIndicator" class="fixed inset-0 bg-gray-900 bg-opacity-75 z-50 flex items-center justify-center hidden">
+            <div class="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-purple-500"></div>
+            <div class="ml-4 text-white">Fetching rates...</div>
+        </div>
+
+        <div id="successMessage" class="fixed top-4 right-4 bg-green-500 text-white py-2 px-4 rounded-full shadow-lg z-50 transition-transform transform translate-x-full hidden">Activity Logged!</div>
+        <div id="errorMessage" class="fixed top-4 right-4 bg-red-500 text-white py-2 px-4 rounded-full shadow-lg z-50 transition-transform transform hidden">Failed to log activity. Please try again.</div>
+
+        <div id="deleteModal" class="modal">
+            <div class="modal-content">
+                <h3 class="text-xl font-bold mb-4">Confirm Deletion</h3>
+                <p class="mb-6">Are you sure you want to delete this entry?</p>
+                <div class="flex justify-center gap-4">
+                    <button id="confirmDeleteBtn" class="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-6 rounded-full transition-colors">Delete</button>
+                    <button id="cancelDeleteBtn" class="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-6 rounded-full transition-colors">Cancel</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="container mx-auto p-8 lg:p-12">
         <h1 class="text-4xl lg:text-5xl font-extrabold text-center mb-6 text-indigo-400">Bond Sales Activity Tracker</h1>
-        <div id="userIdDisplay" class="text-sm text-center mb-6 text-gray-500">User ID: <span id="userIdSpan" class="text-gray-200 font-mono text-xs md:text-sm">Loading...</span></div>
+        <div id="userIdDisplay" class="flex flex-col md:flex-row items-center justify-center md:justify-between gap-3 text-sm mb-6 text-gray-500">
+            <div>User ID: <span id="userIdSpan" class="text-gray-200 font-mono text-xs md:text-sm">Loading...</span></div>
+            <button id="signOutBtn" type="button" class="btn-primary py-2 px-4 md:px-6 text-xs md:text-sm">Sign Out</button>
+        </div>
 
         <div class="bg-gray-800 rounded-xl shadow-2xl p-6 lg:p-10 mb-10">
             <h2 class="text-3xl font-bold mb-6 text-white">Client Database</h2>
@@ -250,9 +297,11 @@
         </div>
     </div>
 
+    </div>
+
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/10.6.0/firebase-app.js";
-        import { getAuth, signInAnonymously, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.6.0/firebase-auth.js";
+        import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.6.0/firebase-auth.js";
         import { getFirestore, doc, addDoc, deleteDoc, onSnapshot, collection, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.6.0/firebase-firestore.js";
         import { setLogLevel } from "https://www.gstatic.com/firebasejs/10.6.0/firebase-firestore.js";
 
@@ -267,8 +316,24 @@ let auth;
 let userId = null;
 let isAuthReady = false;
 let appId;
+let generalUnsub = null;
+let newIssuesUnsub = null;
+let clientsUnsub = null;
 
 
+        const appContent = document.getElementById('appContent');
+        const authOverlay = document.getElementById('authOverlay');
+        const loginForm = document.getElementById('loginForm');
+        const registerForm = document.getElementById('registerForm');
+        const toggleAuthBtn = document.getElementById('toggleAuthBtn');
+        const toggleAuthText = document.getElementById('toggleAuthText');
+        const authTitle = document.getElementById('authTitle');
+        const authMessage = document.getElementById('authMessage');
+        const loginEmailInput = document.getElementById('loginEmail');
+        const loginPasswordInput = document.getElementById('loginPassword');
+        const registerEmailInput = document.getElementById('registerEmail');
+        const registerPasswordInput = document.getElementById('registerPassword');
+        const registerPasswordConfirmInput = document.getElementById('registerPasswordConfirm');
         const allFormFields = document.querySelectorAll('#activityForm input, #activityForm select, #activityForm textarea');
         const clientNameSelect = document.getElementById('clientName');
         const clientNameInputForDb = document.getElementById('newClientName');
@@ -279,6 +344,7 @@ let appId;
         const clientTypeInput = document.getElementById('clientType');
         const clientRegionInput = document.getElementById('clientRegion');
         const securitiesInput = document.getElementById('securities');
+        const buySell = document.getElementById('buySell');
         const cptyTradedAwayInput = document.getElementById('cptyTradedAway');
         const activityTypeInput = document.getElementById('activityType');
         const usdEquivalentInput = document.getElementById('usdEquivalent');
@@ -296,6 +362,7 @@ let appId;
         const confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
         const cancelDeleteBtn = document.getElementById('cancelDeleteBtn');
         const activityHint = document.getElementById('activity-hint');
+        const signOutBtn = document.getElementById('signOutBtn');
 
         // New Issues specific
         const ioiInput = document.getElementById('ioi');
@@ -303,6 +370,108 @@ let appId;
         const realInterestInput = document.getElementById('realInterest');
         const niCurrencySelect = document.getElementById('niCurrency');
         const niUsdEquivalentInput = document.getElementById('niUsdEquivalent');
+
+        const setAuthMessage = (message = '', type = 'error') => {
+            if (!authMessage) return;
+
+            let resolvedMessage = message;
+            let allowHTML = false;
+
+            if (typeof message === 'object' && message !== null) {
+                allowHTML = Boolean(message.allowHTML);
+                resolvedMessage = message.message || message.text || '';
+            }
+
+            if (!resolvedMessage) {
+                authMessage.classList.add('hidden');
+                authMessage.textContent = '';
+                authMessage.innerHTML = '';
+                return;
+            }
+
+            authMessage.classList.remove('hidden');
+            authMessage.classList.remove('text-red-400', 'text-green-400');
+            authMessage.classList.add(type === 'success' ? 'text-green-400' : 'text-red-400');
+
+            if (allowHTML) {
+                authMessage.innerHTML = resolvedMessage;
+            } else {
+                authMessage.textContent = resolvedMessage;
+            }
+        };
+
+        let authFormsDisabled = false;
+        const disableAuthForms = () => {
+            if (authFormsDisabled) return;
+            authFormsDisabled = true;
+            [loginForm, registerForm].forEach((form) => {
+                if (!form) return;
+                form.querySelectorAll('input, button').forEach((element) => {
+                    element.disabled = true;
+                    element.classList.add('opacity-60', 'cursor-not-allowed');
+                });
+            });
+        };
+
+        const getFriendlyAuthErrorMessage = (error) => {
+            const fallback = {
+                message: 'An unexpected authentication error occurred. Please try again.',
+            };
+
+            if (!error) {
+                return fallback;
+            }
+
+            const code = error.code || '';
+            switch (code) {
+                case 'auth/operation-not-allowed':
+                    return {
+                        allowHTML: true,
+                        disableAuthForms: true,
+                        message: `
+                            <div class="space-y-3 text-left">
+                                <p class="font-semibold text-red-200">Email/password authentication is disabled for this Firebase project.</p>
+                                <p class="text-gray-300">Enable it to allow people to register and sign in:</p>
+                                <ol class="list-decimal list-inside space-y-1 text-gray-300">
+                                    <li>Open the <a href="https://console.firebase.google.com/" target="_blank" rel="noopener" class="text-indigo-300 underline">Firebase console</a> and select your project.</li>
+                                    <li>Go to <strong>Build → Authentication → Sign-in method</strong>.</li>
+                                    <li>Activate the <strong>Email/Password</strong> provider and click <strong>Save</strong>.</li>
+                                </ol>
+                                <p class="text-xs text-gray-400">After enabling the provider, reload this page and try again.</p>
+                            </div>
+                        `.trim(),
+                    };
+                case 'auth/email-already-in-use':
+                    return { message: 'An account already exists for that email address.' };
+                case 'auth/invalid-email':
+                    return { message: 'Please enter a valid email address.' };
+                case 'auth/weak-password':
+                    return { message: 'Passwords must be at least 6 characters long.' };
+                case 'auth/user-not-found':
+                    return { message: "We couldn't find an account with that email." };
+                case 'auth/wrong-password':
+                    return { message: 'Incorrect password. Please try again.' };
+                default:
+                    return { message: error.message || fallback.message };
+            }
+        };
+
+        const switchAuthView = (view = 'login') => {
+            if (view === 'register') {
+                loginForm.classList.add('hidden');
+                registerForm.classList.remove('hidden');
+                authTitle.textContent = 'Create Account';
+                toggleAuthText.textContent = 'Already have an account?';
+                toggleAuthBtn.textContent = 'Sign In';
+            } else {
+                registerForm.classList.add('hidden');
+                loginForm.classList.remove('hidden');
+                authTitle.textContent = 'Sign In';
+                toggleAuthText.textContent = "Don't have an account?";
+                toggleAuthBtn.textContent = 'Register';
+            }
+            setAuthMessage('');
+        };
 
         const showMessage = (element, message, duration = 2500) => {
             element.textContent = message;
@@ -324,24 +493,151 @@ let appId;
             const newIssuesPath = `artifacts/${appId}/users/${userId}/new_issues`;
             const clientsPath = `artifacts/${appId}/clients`;
 
-            onSnapshot(collection(db, generalActivitiesPath), (snapshot) => {
+            if (generalUnsub) generalUnsub();
+            generalUnsub = onSnapshot(collection(db, generalActivitiesPath), (snapshot) => {
                 const activities = [];
                 snapshot.forEach(doc => activities.push({ id: doc.id, ...doc.data() }));
                 renderGeneralActivities(activities);
             }, (error) => { console.error('Error fetching general activities:', error); showMessage(errorMessage, `Failed to load activities: ${error.message}`); });
 
-            onSnapshot(collection(db, newIssuesPath), (snapshot) => {
+            if (newIssuesUnsub) newIssuesUnsub();
+            newIssuesUnsub = onSnapshot(collection(db, newIssuesPath), (snapshot) => {
                 const newIssues = [];
                 snapshot.forEach(doc => newIssues.push({ id: doc.id, ...doc.data() }));
                 renderNewIssues(newIssues);
             }, (error) => { console.error('Error fetching new issues:', error); showMessage(errorMessage, `Failed to load new issues: ${error.message}`); });
 
-            onSnapshot(collection(db, clientsPath), (snapshot) => {
+            if (clientsUnsub) clientsUnsub();
+            clientsUnsub = onSnapshot(collection(db, clientsPath), (snapshot) => {
                 const clients = [];
                 snapshot.forEach(doc => clients.push({ id: doc.id, ...doc.data() }));
                 populateClientDropdown(clients);
             }, (error) => { console.error('Error fetching clients:', error); showMessage(errorMessage, `Failed to load clients: ${error.message}`); });
         };
+
+        const clearRealtimeListeners = () => {
+            if (generalUnsub) { generalUnsub(); generalUnsub = null; }
+            if (newIssuesUnsub) { newIssuesUnsub(); newIssuesUnsub = null; }
+            if (clientsUnsub) { clientsUnsub(); clientsUnsub = null; }
+        };
+
+        const resetAppState = () => {
+            generalLogTable.innerHTML = '';
+            newIssuesLogTable.innerHTML = '';
+            clientsListDiv.textContent = 'Sign in to view clients.';
+            clientNameSelect.innerHTML = '<option value="">(Select client from Client Database)</option>';
+            clientNameSelect.disabled = true;
+            clientTypeInput.value = '';
+            clientRegionInput.value = '';
+            securitiesInput.value = '';
+            cptyTradedAwayInput.value = '';
+            activityForm.reset();
+            activityTypeInput.value = '';
+            tabButtons.forEach(btn => btn.classList.remove('active'));
+            const generalTab = document.getElementById('log-general-tab');
+            const newIssuesTab = document.getElementById('log-new-issues-tab');
+            if (generalTab) generalTab.classList.add('active');
+            if (newIssuesTab) newIssuesTab.classList.remove('active');
+            document.getElementById('generalLog').classList.remove('hidden');
+            document.getElementById('newIssuesLog').classList.add('hidden');
+            showFormFields('');
+            activityHint.classList.remove('hidden');
+            submitBtn.disabled = true;
+        };
+
+        switchAuthView('login');
+
+        toggleAuthBtn.addEventListener('click', () => {
+            const isShowingLogin = !loginForm.classList.contains('hidden');
+            switchAuthView(isShowingLogin ? 'register' : 'login');
+        });
+
+        if (loginForm) {
+            loginForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                if (!auth) return;
+                const email = (loginEmailInput.value || '').trim();
+                const password = loginPasswordInput.value || '';
+                if (!email || !password) {
+                    setAuthMessage('Please provide your email and password.');
+                    return;
+                }
+
+                const submitButton = loginForm.querySelector('button[type="submit"]');
+                const originalText = submitButton.textContent;
+                submitButton.disabled = true;
+                submitButton.textContent = 'Signing In...';
+                setAuthMessage('Signing in...', 'success');
+
+                try {
+                    await signInWithEmailAndPassword(auth, email, password);
+                    setAuthMessage('Signed in successfully!', 'success');
+                } catch (err) {
+                    console.error('Sign in failed', err);
+                    const friendlyError = getFriendlyAuthErrorMessage(err);
+                    setAuthMessage(friendlyError);
+                    if (friendlyError?.disableAuthForms) {
+                        disableAuthForms();
+                    }
+                } finally {
+                    submitButton.disabled = false;
+                    submitButton.textContent = originalText;
+                }
+            });
+        }
+
+        if (registerForm) {
+            registerForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                if (!auth) return;
+                const email = (registerEmailInput.value || '').trim();
+                const password = registerPasswordInput.value || '';
+                const confirmPassword = registerPasswordConfirmInput.value || '';
+
+                if (!email || !password || !confirmPassword) {
+                    setAuthMessage('Please complete all fields.');
+                    return;
+                }
+
+                if (password !== confirmPassword) {
+                    setAuthMessage('Passwords do not match.');
+                    return;
+                }
+
+                const submitButton = registerForm.querySelector('button[type="submit"]');
+                const originalText = submitButton.textContent;
+                submitButton.disabled = true;
+                submitButton.textContent = 'Creating...';
+                setAuthMessage('Creating your account...', 'success');
+
+                try {
+                    await createUserWithEmailAndPassword(auth, email, password);
+                    setAuthMessage('Account created! You are now signed in.', 'success');
+                } catch (err) {
+                    console.error('Registration failed', err);
+                    const friendlyError = getFriendlyAuthErrorMessage(err);
+                    setAuthMessage(friendlyError);
+                    if (friendlyError?.disableAuthForms) {
+                        disableAuthForms();
+                    }
+                } finally {
+                    submitButton.disabled = false;
+                    submitButton.textContent = originalText;
+                }
+            });
+        }
+
+        if (signOutBtn) {
+            signOutBtn.addEventListener('click', async () => {
+                if (!auth) return;
+                try {
+                    await signOut(auth);
+                } catch (err) {
+                    console.error('Sign out failed', err);
+                    showMessage(errorMessage, 'Failed to sign out.');
+                }
+            });
+        }
 
         const tabButtons = document.querySelectorAll('#tab-enquiry, #tab-trade, #tab-missed-trades, #tab-new-issues');
         const generalTabs = document.querySelectorAll('#log-general-tab, #log-new-issues-tab');
@@ -788,7 +1084,7 @@ const populateClientDropdown = (clients) => {
 
 const initApp = async () => {
 
-            const firebaseConfig = {
+            const firebaseConfig = {
 
   apiKey: "AIzaSyBkQnlYdOsIki_VuEpMBsIFACLN-u2FYFo",
   authDomain: "bond-sales-tracker.firebaseapp.com",
@@ -799,52 +1095,52 @@ const initApp = async () => {
 
 
 
-            };
+            };
 
 
-
-
-
-const initialAuthToken = typeof __initial_auth_token !== 'undefined' ? __initial_auth_token : null;
 
 try {
-    app = initializeApp(firebaseConfig);   // ✅ assign to the outer "app"
+    app = initializeApp(firebaseConfig);
     db = getFirestore(app);
     auth = getAuth(app);
-    appId = firebaseConfig.projectId;      // ✅ give appId a value
+    appId = firebaseConfig.projectId;
 } catch (e) {
     console.error('Firebase init failed', e);
     showMessage(errorMessage, 'Firebase initialization failed. Check your config.');
     return;
 }
 
+resetAppState();
+appContent.classList.add('hidden');
+authOverlay.classList.remove('hidden');
+document.getElementById('userIdSpan').textContent = 'Not signed in';
 
             onAuthStateChanged(auth, (user) => {
+                clearRealtimeListeners();
                 if (user) {
                     userId = user.uid;
                     document.getElementById('userIdSpan').textContent = userId;
                     isAuthReady = true;
+                    appContent.classList.remove('hidden');
+                    authOverlay.classList.add('hidden');
+                    switchAuthView('login');
+                    setAuthMessage('');
+                    if (loginForm) loginForm.reset();
+                    if (registerForm) registerForm.reset();
                     setupRealtimeListeners();
                     updateSubmitButtonState();
                 } else {
-                    signInAnonymously(auth).then(() => console.log('Signed in anonymously')).catch(err => {
-                        console.error('Anon sign-in failed', err);
-                        document.getElementById('userIdSpan').textContent = 'Auth Error';
-                        showMessage(errorMessage, 'Authentication failed.');
-                    });
+                    userId = null;
+                    isAuthReady = false;
+                    document.getElementById('userIdSpan').textContent = 'Not signed in';
+                    resetAppState();
+                    appContent.classList.add('hidden');
+                    authOverlay.classList.remove('hidden');
+                    switchAuthView('login');
+                    setAuthMessage('');
+                    updateSubmitButtonState();
                 }
             });
-
-            if (initialAuthToken) {
-                try {
-                    await signInWithCustomToken(auth, initialAuthToken);
-                } catch (err) {
-                    console.error('Custom token sign-in failed', err);
-                    signInAnonymously(auth).catch(() => {});
-                }
-            } else {
-                signInAnonymously(auth).catch(() => {});
-            }
         };
         
         document.addEventListener('DOMContentLoaded', initApp);


### PR DESCRIPTION
## Summary
- allow the authentication overlay to render rich guidance and disable its forms when Firebase email/password sign-in is unavailable
- surface detailed setup steps instead of the raw Firebase error for the `auth/operation-not-allowed` failure

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dcec990010832c9ac48b4b5a1d6144